### PR TITLE
Ignore existing installation when running installPipPackageTask

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ installPipPackageTask := {
   publishLocal.value
   packagePythonTask.value
   Process(
-    activateCondaEnv ++ Seq("pip", "install",
+    activateCondaEnv ++ Seq("pip", "install", "-I",
       s"mmlspark-${pythonizedVersion.value}-py2.py3-none-any.whl"),
     pythonPackageDir) ! s.log
 }


### PR DESCRIPTION
When iterating in a dev environment this ensures that it always overwrites the already installed version.

```
-I, --ignore-installed      Ignore the installed packages, overwriting them. This can break your system if the existing package is
                              of a different version or was installed with a different package manager!
```